### PR TITLE
feat(articles-list): add long-press mark-as-read to category items

### DIFF
--- a/app/src/androidTest/java/com/geekorum/ttrss/sync/workers/mocks.kt
+++ b/app/src/androidTest/java/com/geekorum/ttrss/sync/workers/mocks.kt
@@ -83,6 +83,10 @@ internal open class MockApiService : ApiService {
         TODO("Not yet implemented")
     }
 
+    override suspend fun markCategoryAsRead(categoryId: Long) {
+        TODO("Not yet implemented")
+    }
+
 }
 
 

--- a/app/src/main/java/com/geekorum/ttrss/articles_list/ArticlesRepository.kt
+++ b/app/src/main/java/com/geekorum/ttrss/articles_list/ArticlesRepository.kt
@@ -154,6 +154,10 @@ class ArticlesRepository
         articleDao.updateArticleUnreadForFeed(feedId, newValue)
     }
 
+    suspend fun setArticlesUnreadForCategory(catId: Long, newValue: Boolean) {
+        articleDao.updateArticleUnreadForCategory(catId, newValue)
+    }
+
     fun searchArticles(query: String): PagingSource<Int, ArticleWithFeed> {
         return articleDao.searchArticles(query)
     }

--- a/app/src/main/java/com/geekorum/ttrss/articles_list/FeedListNavigationMenu.kt
+++ b/app/src/main/java/com/geekorum/ttrss/articles_list/FeedListNavigationMenu.kt
@@ -192,6 +192,7 @@ fun CategorizedFeedSection(
     onFeedSelected: (Feed) -> Unit,
     onMarkFeedAsReadClick: (Feed) -> Unit,
     onCategoryClick: (Category) -> Unit,
+    onMarkCategoryAsReadClick: (Category) -> Unit,
 ) {
     SectionLabel(stringResource(R.string.title_feeds_menu))
     NavigationItem(stringResource(R.string.title_magazine),
@@ -214,7 +215,8 @@ fun CategorizedFeedSection(
                     isExpanded = true
                     onCategoryClick(category)
                 },
-                onToggleExpand = { isExpanded = !isExpanded }
+                onToggleExpand = { isExpanded = !isExpanded },
+                onMarkCategoryAsReadClick = onMarkCategoryAsReadClick,
             )
             if (isExpanded) {
                 for (feedWithFavIcon in feeds) {
@@ -232,41 +234,67 @@ private fun CategoryHeader(
     isSelected: Boolean,
     onCategoryClick: () -> Unit,
     onToggleExpand: () -> Unit,
+    onMarkCategoryAsReadClick: (Category) -> Unit,
 ) {
     val chevronRotation by animateFloatAsState(
         targetValue = if (isExpanded) 180f else 0f,
         animationSpec = tween(300),
         label = "chevronRotation"
     )
-    NavigationDrawerItem(
-        label = {
-            Text(
-                text = category.title,
-                style = MaterialTheme.typography.labelLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+    Box {
+        var displayDropdownMenu by remember { mutableStateOf(false) }
+        NavigationDrawerItem(
+            label = {
+                Text(
+                    text = category.title,
+                    style = MaterialTheme.typography.labelLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
+            selected = isSelected || displayDropdownMenu,
+            colors = if (displayDropdownMenu)
+                NavigationDrawerItemDefaults.colors(
+                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            else NavigationDrawerItemDefaults.colors(),
+            onClick = onCategoryClick,
+            icon = { Icon(Icons.Default.Folder, contentDescription = null) },
+            badge = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (category.unreadCount > 0) {
+                        Text(category.unreadCount.toString())
+                        Spacer(Modifier.width(4.dp))
+                    }
+                    IconButton(onClick = onToggleExpand, modifier = Modifier.size(24.dp)) {
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowDown,
+                            contentDescription = null,
+                            modifier = Modifier.rotate(chevronRotation),
+                        )
+                    }
+                }
+            },
+            modifier = Modifier
+                .interceptLongClick { displayDropdownMenu = true }
+                .padding(NavigationDrawerItemDefaults.ItemPadding)
+        )
+        DropdownMenu(
+            expanded = displayDropdownMenu,
+            onDismissRequest = { displayDropdownMenu = false },
+            offset = DpOffset(x = 16.dp, y = (-8).dp)
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.mark_as_read)) },
+                onClick = {
+                    onMarkCategoryAsReadClick(category)
+                    displayDropdownMenu = false
+                }
             )
-        },
-        selected = isSelected,
-        onClick = onCategoryClick,
-        icon = { Icon(Icons.Default.Folder, contentDescription = null) },
-        badge = {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                if (category.unreadCount > 0) {
-                    Text(category.unreadCount.toString())
-                    Spacer(Modifier.width(4.dp))
-                }
-                IconButton(onClick = onToggleExpand, modifier = Modifier.size(24.dp)) {
-                    Icon(
-                        imageVector = Icons.Default.KeyboardArrowDown,
-                        contentDescription = null,
-                        modifier = Modifier.rotate(chevronRotation),
-                    )
-                }
-            }
-        },
-        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
-    )
+        }
+    }
 }
 
 @Composable
@@ -595,6 +623,7 @@ fun PreviewCategorizedFeedListNavigationMenu() {
                             },
                             onMarkFeedAsReadClick = {},
                             onCategoryClick = {},
+                            onMarkCategoryAsReadClick = {},
                         )
                     },
                     manageFeedsSection = {

--- a/app/src/main/java/com/geekorum/ttrss/articles_list/FeedListNavigationMenu.kt
+++ b/app/src/main/java/com/geekorum/ttrss/articles_list/FeedListNavigationMenu.kt
@@ -243,24 +243,12 @@ private fun CategoryHeader(
     )
     Box {
         var displayDropdownMenu by remember { mutableStateOf(false) }
-        NavigationDrawerItem(
-            label = {
-                Text(
-                    text = category.title,
-                    style = MaterialTheme.typography.labelLarge,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            },
-            selected = isSelected || displayDropdownMenu,
-            colors = if (displayDropdownMenu)
-                NavigationDrawerItemDefaults.colors(
-                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                    selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            else NavigationDrawerItemDefaults.colors(),
+        NavigationItem(
+            category.title,
+            selected = isSelected,
+            selectedForAction = displayDropdownMenu,
             onClick = onCategoryClick,
+            onLongClick = { displayDropdownMenu = true },
             icon = { Icon(Icons.Default.Folder, contentDescription = null) },
             badge = {
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -277,9 +265,6 @@ private fun CategoryHeader(
                     }
                 }
             },
-            modifier = Modifier
-                .interceptLongClick { displayDropdownMenu = true }
-                .padding(NavigationDrawerItemDefaults.ItemPadding)
         )
         DropdownMenu(
             expanded = displayDropdownMenu,

--- a/app/src/main/java/com/geekorum/ttrss/articles_list/FeedListNavigationMenu.kt
+++ b/app/src/main/java/com/geekorum/ttrss/articles_list/FeedListNavigationMenu.kt
@@ -287,7 +287,7 @@ private fun CategoryHeader(
             offset = DpOffset(x = 16.dp, y = (-8).dp)
         ) {
             DropdownMenuItem(
-                text = { Text(stringResource(R.string.mark_as_read)) },
+                text = { Text(stringResource(R.string.menu_item_mark_category_as_read)) },
                 onClick = {
                     onMarkCategoryAsReadClick(category)
                     displayDropdownMenu = false

--- a/app/src/main/java/com/geekorum/ttrss/articles_list/FeedsNavigationMenuPresenter.kt
+++ b/app/src/main/java/com/geekorum/ttrss/articles_list/FeedsNavigationMenuPresenter.kt
@@ -145,7 +145,8 @@ class FeedsNavigationMenuPresenter(
                         onCategoryClick = { category ->
                             navigateToCategory(category)
                             onNavigation()
-                        }
+                        },
+                        onMarkCategoryAsReadClick = feedsViewModel::markCategoryAsRead,
                     )
                 } else {
                     FeedSection(

--- a/app/src/main/java/com/geekorum/ttrss/articles_list/FeedsViewModel.kt
+++ b/app/src/main/java/com/geekorum/ttrss/articles_list/FeedsViewModel.kt
@@ -153,4 +153,16 @@ class FeedsViewModel @Inject constructor(
         }
     }
 
+    fun markCategoryAsRead(category: Category) = viewModelScope.launch {
+        withContext(dispatchers.io) {
+            try {
+                apiService.markCategoryAsRead(category.id)
+                articlesRepository.setArticlesUnreadForCategory(category.id, false)
+                refreshFeeds()
+            } catch (e: ApiCallException) {
+                Timber.w(e, "Unable to mark category as read")
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/geekorum/ttrss/data/ArticleDao.kt
+++ b/app/src/main/java/com/geekorum/ttrss/data/ArticleDao.kt
@@ -159,6 +159,10 @@ interface ArticleDao {
     @Query("UPDATE articles SET transiant_unread=:isUnread, unread=:isUnread WHERE feed_id=:feedId")
     suspend fun updateArticleUnreadForFeed(feedId: Long, isUnread: Boolean): Int
 
+    @Query("UPDATE articles SET transiant_unread=:isUnread, unread=:isUnread " +
+        "WHERE feed_id IN (SELECT _id FROM feeds WHERE cat_id=:catId)")
+    suspend fun updateArticleUnreadForCategory(catId: Long, isUnread: Boolean): Int
+
     @Query("UPDATE articles SET marked=:isMarked WHERE _id=:articleId")
     suspend fun updateArticleMarked(articleId: Long, isMarked: Boolean): Int
 

--- a/app/src/main/java/com/geekorum/ttrss/network/ApiRetrofitService.kt
+++ b/app/src/main/java/com/geekorum/ttrss/network/ApiRetrofitService.kt
@@ -124,6 +124,13 @@ class ApiRetrofitService(
         }
     }
 
+    override suspend fun markCategoryAsRead(categoryId: Long) {
+        val payload = CatchupFeedRequestPayload(categoryId, isCategory = true)
+        executeOrFail("Unable to mark category as read") {
+            tinyrssApi.catchupFeed(payload)
+        }
+    }
+
     override suspend fun getServerInfo(): ServerInfo = supervisorScope {
         val versionDeferred = async {
             val payload = GetVersionRequestPayload()

--- a/app/src/main/java/com/geekorum/ttrss/network/ApiService.kt
+++ b/app/src/main/java/com/geekorum/ttrss/network/ApiService.kt
@@ -64,6 +64,9 @@ interface ApiService {
     @Throws(ApiCallException::class)
     suspend fun markFeedAsRead(feedId: Long)
 
+    @Throws(ApiCallException::class)
+    suspend fun markCategoryAsRead(categoryId: Long)
+
     companion object {
         val ALL_ARTICLES_FEED_ID: Long = -4
     }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -39,7 +39,8 @@
     <string name="sort_order_most_recent_first">Le plus récent</string>
     <string name="sort_order_oldest_first">Le plus vieux</string>
     <string name="title_article_search">Recherche</string>
-    <string name="menu_item_mark_feed_as_read">Marquer comme lu</string>
+    <string name="menu_item_mark_feed_as_read">Marquer le flux comme lu</string>
+    <string name="menu_item_mark_category_as_read">Marquer la catégorie comme lue</string>
     <string name="label_articles_search_no_results">Pas d\'articles trouvés pour \"%1$s\"</string>
     <string name="title_article_details">Détails de l\'article</string>
     <string name="title_feeds_menu">Flux</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,8 @@
     <string name="title_article_search">Search</string>
     <string name="label_feed_name" translatable="false">{feed_name}</string>
     <string name="label_tag" translatable="false">#{tag}</string>
-    <string name="menu_item_mark_feed_as_read">Mark as read</string>
+    <string name="menu_item_mark_feed_as_read">Mark feed as read</string>
+    <string name="menu_item_mark_category_as_read">Mark category as read</string>
     <string name="label_articles_search_no_results">No articles found for \"%1$s\"</string>
     <string name="label_articles_search_no_results_instructions">Check the spelling or try a different search term</string>
 


### PR DESCRIPTION
## Summary
- Add long-press support on category items in the feed navigation drawer to reveal a dropdown menu with a "Mark category as read" action, mirroring the existing per-feed long-press mark-as-read behavior.
- Distinguish the mark-as-read menu item labels for feeds vs categories ("Mark feed as read" / "Mark category as read") for clarity now that both actions exist side by side.
- Adds `ApiService.markCategoryAsRead`, backed by the existing tt-rss `catchupFeed` API call with `isCategory = true`, and a `ArticleDao.updateArticleUnreadForCategory` query to update local unread state for all feeds within the category.

## Test plan
- [ ] Long-press a category in the navigation drawer and verify the dropdown menu appears with "Mark category as read"
- [ ] Tap the action and confirm all feeds/articles in that category are marked read both locally and on the tt-rss server
- [ ] Verify existing per-feed long-press mark-as-read still works and its label now reads "Mark feed as read"